### PR TITLE
Display moves for both combatants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # ProjectBreak3
 
-ideas:
+Este repositorio contiene un ejemplo muy sencillo del juego propuesto en el README inicial.
 
-crear un pokemon de piedra papel o tijera donde hay 10 mounstros y 7 de ellos estan bloqueados,
-despues de cada 5 combates desbloqueas a uno por orden de rareza (comun, poco comun, epico legendario)
-si sacas papel y un moustro de tu misma rareza saca papel es un empate pero si es un mousntro epico y tu llevas uno normal y sacais los dos tijera el gana solo puedes ganarle usando la eleccion correcta
+El juego consiste en combatir con monstruos usando un sistema de piedra, papel o tijera.
+Hay 10 monstruos de distintas rarezas y se van desbloqueando cada cinco combates.
+
+## Ejecutar
+
+Sirve los archivos con un servidor web local. Por ejemplo, puedes ejecutar:
+
+```bash
+python3 -m http.server 8000
+```
+
+Luego visita `http://localhost:8000/public/` en tu navegador. **No** abras el
+archivo directamente con `file://`, ya que Babel intenta cargar `src/app.jsx`
+a trav\u00e9s de HTTP y el navegador bloquear\u00e1 la solicitud.

--- a/public/images/bicho.svg
+++ b/public/images/bicho.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#a2d9ce" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">B</text>
+</svg>

--- a/public/images/dragon.svg
+++ b/public/images/dragon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#b2b7e5" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">D</text>
+</svg>

--- a/public/images/fenix.svg
+++ b/public/images/fenix.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#f7dc6f" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">F</text>
+</svg>

--- a/public/images/golem.svg
+++ b/public/images/golem.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#d0c4aa" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">G</text>
+</svg>

--- a/public/images/harpia.svg
+++ b/public/images/harpia.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#e6b0aa" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">H</text>
+</svg>

--- a/public/images/kraken.svg
+++ b/public/images/kraken.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#a9cce3" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">K</text>
+</svg>

--- a/public/images/lobo.svg
+++ b/public/images/lobo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#cccccc" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">L</text>
+</svg>

--- a/public/images/orco.svg
+++ b/public/images/orco.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#7fbf7f" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">O</text>
+</svg>

--- a/public/images/rata.svg
+++ b/public/images/rata.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#f4d6d6" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">R</text>
+</svg>

--- a/public/images/topo.svg
+++ b/public/images/topo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <rect width="80" height="80" fill="#d9cbb3" />
+  <text x="40" y="45" font-size="24" text-anchor="middle" fill="#000">T</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Monstruos Piedra Papel Tijera</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 20px;
+      background-color: #f4f4f4;
+    }
+    #root {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    label { margin-right: 10px; }
+    button {
+      margin-right: 5px;
+      padding: 6px 12px;
+      background-color: #4CAF50;
+      border: none;
+      color: #fff;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    button:hover { background-color: #45a049; }
+    h1, h2 { text-align: center; }
+    .monster-list { list-style: none; padding: 0; }
+    .monster-list li {
+      background: #eee;
+      margin-bottom: 4px;
+      padding: 4px 8px;
+      border-radius: 4px;
+    }
+    .monster-list img {
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="../src/app.jsx"></script>
+</body>
+</html>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,0 +1,302 @@
+const { useState } = React;
+
+const rarities = {
+  common: 1,
+  "poco comun": 2,
+  epico: 3,
+  legendario: 4
+};
+
+const initialMonsters = [
+  {
+    id: 1,
+    name: "Bicho",
+    rarity: "common",
+    unlocked: true,
+    image: "images/bicho.svg",
+    abilities: {
+      piedra: "Caparaz\u00f3n duro",
+      papel: "Envoltura pegajosa",
+      tijera: "Pinzas agudas"
+    }
+  },
+  {
+    id: 2,
+    name: "Topo",
+    rarity: "common",
+    unlocked: true,
+    image: "images/topo.svg",
+    abilities: {
+      piedra: "Golpe subterr\u00e1neo",
+      papel: "Mont\u00f3n de tierra",
+      tijera: "Ara\u00f1azo"
+    }
+  },
+  {
+    id: 3,
+    name: "Rata",
+    rarity: "common",
+    unlocked: true,
+    image: "images/rata.svg",
+    abilities: {
+      piedra: "Mordisco roedor",
+      papel: "Cola flexible",
+      tijera: "Ara\u00f1azo r\u00e1pido"
+    }
+  },
+  {
+    id: 4,
+    name: "Lobo",
+    rarity: "common",
+    unlocked: false,
+    image: "images/lobo.svg",
+    abilities: {
+      piedra: "Embestida",
+      papel: "Aullido aturdidor",
+      tijera: "Mordida salvaje"
+    }
+  },
+  {
+    id: 5,
+    name: "Orco",
+    rarity: "poco comun",
+    unlocked: false,
+    image: "images/orco.svg",
+    abilities: {
+      piedra: "Mazo pesado",
+      papel: "Escudo improvisado",
+      tijera: "Hachazo"
+    }
+  },
+  {
+    id: 6,
+    name: "Golem",
+    rarity: "poco comun",
+    unlocked: false,
+    image: "images/golem.svg",
+    abilities: {
+      piedra: "Pu\u00f1o de roca",
+      papel: "Torbellino de polvo",
+      tijera: "Aplastamiento"
+    }
+  },
+  {
+    id: 7,
+    name: "Harpia",
+    rarity: "poco comun",
+    unlocked: false,
+    image: "images/harpia.svg",
+    abilities: {
+      piedra: "Picotazo",
+      papel: "Plumas cortantes",
+      tijera: "Garras r\u00e1pidas"
+    }
+  },
+  {
+    id: 8,
+    name: "Dragon",
+    rarity: "epico",
+    unlocked: false,
+    image: "images/dragon.svg",
+    abilities: {
+      piedra: "Golpe de cola",
+      papel: "Ala protectora",
+      tijera: "Aliento de fuego"
+    }
+  },
+  {
+    id: 9,
+    name: "Kraken",
+    rarity: "epico",
+    unlocked: false,
+    image: "images/kraken.svg",
+    abilities: {
+      piedra: "Tent\u00e1culo poderoso",
+      papel: "Tinta envolvente",
+      tijera: "Agarre cortante"
+    }
+  },
+  {
+    id: 10,
+    name: "Fenix",
+    rarity: "legendario",
+    unlocked: false,
+    image: "images/fenix.svg",
+    abilities: {
+      piedra: "Llama eterna",
+      papel: "Canto revitalizador",
+      tijera: "Vuelo abrasador"
+    }
+  }
+];
+
+const choices = ["piedra", "papel", "tijera"];
+
+function getWinner(playerMove, playerMonster, enemyMove, enemyMonster) {
+  if (playerMove === enemyMove) {
+    if (rarities[playerMonster.rarity] < rarities[enemyMonster.rarity]) {
+      return "enemy";
+    }
+    return "tie";
+  }
+  if (
+    (playerMove === "piedra" && enemyMove === "tijera") ||
+    (playerMove === "papel" && enemyMove === "piedra") ||
+    (playerMove === "tijera" && enemyMove === "papel")
+  ) {
+    return "player";
+  }
+  return "enemy";
+}
+
+function App() {
+  const [monsters, setMonsters] = useState(initialMonsters);
+  const [playerMonsterId, setPlayerMonsterId] = useState(1);
+  const [battleCount, setBattleCount] = useState(0);
+  const [wins, setWins] = useState(0);
+  const [losses, setLosses] = useState(0);
+  const [result, setResult] = useState(null);
+  const [lastBattle, setLastBattle] = useState(null);
+
+  const unlockedMonsters = monsters.filter(m => m.unlocked);
+
+  function handleMove(move) {
+    const playerMonster = monsters.find(m => m.id === playerMonsterId);
+    const enemyMonster = monsters[Math.floor(Math.random() * monsters.length)];
+    const enemyMove = choices[Math.floor(Math.random() * choices.length)];
+    const winner = getWinner(move, playerMonster, enemyMove, enemyMonster);
+
+    let message;
+    if (winner === "player") {
+      message = "\u00A1Ganaste!";
+      setWins(wins + 1);
+    } else if (winner === "enemy") {
+      message = "Perdiste";
+      setLosses(losses + 1);
+    } else {
+      message = "Empate";
+    }
+    setResult(message);
+    setLastBattle({
+      playerMonster,
+      playerMove: move,
+      enemyMonster,
+      enemyMove
+    });
+
+    const newCount = battleCount + 1;
+    setBattleCount(newCount);
+
+    if (newCount % 5 === 0) {
+      const index = monsters.findIndex(m => !m.unlocked);
+      if (index !== -1) {
+        const updated = monsters.slice();
+        updated[index].unlocked = true;
+        setMonsters(updated);
+      }
+    }
+  }
+
+  return (
+    <div>
+      <h1>Combate de Monstruos</h1>
+      <p>
+        Combates: {battleCount} | Victorias: {wins} | Derrotas: {losses}
+      </p>
+
+      <div>
+        <h2>Selecciona tu monstruo</h2>
+        {unlockedMonsters.map(m => (
+          <label key={m.id} style={{ marginRight: "10px" }}>
+            <input
+              type="radio"
+              value={m.id}
+              checked={playerMonsterId === m.id}
+              onChange={() => setPlayerMonsterId(m.id)}
+            />
+            <img
+              src={m.image}
+              alt={m.name}
+              width="40"
+              style={{ verticalAlign: "middle", marginRight: "4px" }}
+            />
+            {m.name} ({m.rarity})
+          </label>
+        ))}
+      </div>
+
+      <div style={{ marginTop: "20px" }}>
+        <h2>Elige tu movimiento</h2>
+        {choices.map(choice => (
+          <button key={choice} onClick={() => handleMove(choice)}>
+            {choice}
+          </button>
+        ))}
+      </div>
+
+      {lastBattle && (
+        <div style={{ marginTop: "20px" }}>
+          <h3>
+            Tu monstruo: {lastBattle.playerMonster.name} ({lastBattle.playerMonster.rarity})
+          </h3>
+          <img
+            src={lastBattle.playerMonster.image}
+            alt={lastBattle.playerMonster.name}
+            width="60"
+            style={{ display: "block", marginBottom: "10px" }}
+          />
+          <p>
+            Tu movimiento: {lastBattle.playerMonster.abilities[lastBattle.playerMove]} ({lastBattle.playerMove})
+          </p>
+          <h3>
+            Enemigo: {lastBattle.enemyMonster.name} ({lastBattle.enemyMonster.rarity})
+          </h3>
+          <img
+            src={lastBattle.enemyMonster.image}
+            alt={lastBattle.enemyMonster.name}
+            width="60"
+            style={{ display: "block", marginBottom: "10px" }}
+          />
+          <p>
+            Movimiento del enemigo: {lastBattle.enemyMonster.abilities[lastBattle.enemyMove]} ({lastBattle.enemyMove})
+          </p>
+        </div>
+      )}
+
+      {result && <h2 style={{ marginTop: "10px" }}>{result}</h2>}
+
+      <div style={{ marginTop: "20px" }}>
+        <h2>Monstruos desbloqueados</h2>
+        <ul className="monster-list">
+          {monsters.filter(m => m.unlocked).map(m => (
+            <li key={m.id}>
+              <img
+                src={m.image}
+                alt={m.name}
+                width="30"
+                style={{ verticalAlign: "middle", marginRight: "4px" }}
+              />
+              {m.name} ({m.rarity})
+            </li>
+          ))}
+        </ul>
+        <h2>Bloqueados</h2>
+        <ul className="monster-list">
+          {monsters.filter(m => !m.unlocked).map(m => (
+            <li key={m.id}>
+              <img
+                src={m.image}
+                alt={m.name}
+                width="30"
+                style={{ verticalAlign: "middle", marginRight: "4px" }}
+              />
+              {m.name} ({m.rarity})
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- add a `lastBattle` state storing both monsters and their moves
- show player's monster, enemy monster and their chosen moves after each fight
- track wins and losses and display them
- give every monster custom abilities that map to piedra, papel or tijera

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fd95837b88325bad92ed7756ed4be